### PR TITLE
[NSudo.vcxproj] Use latest available Windows 10 SDK

### DIFF
--- a/NSudo/NSudo.vcxproj
+++ b/NSudo/NSudo.vcxproj
@@ -70,7 +70,7 @@
     <ProjectGuid>{DBC9A9EE-78AE-4260-80E8-67D4D04A92C8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>NSudo</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccAuxPath>SAK</SccAuxPath>
     <SccLocalPath>SAK</SccLocalPath>


### PR DESCRIPTION
Fixes #26. (regression caused by https://github.com/M2Team/NSudo/commit/cf11a97e540c77d716d0b555bce5d6d5f30e410e)